### PR TITLE
require file type for the provisioner

### DIFF
--- a/lib/config_builder/model.rb
+++ b/lib/config_builder/model.rb
@@ -59,6 +59,7 @@ module ConfigBuilder
         @registry.register(name, klass)
       end
 
+      require 'config_builder/model/provisioner/file'
       require 'config_builder/model/provisioner/shell'
       require 'config_builder/model/provisioner/puppet'
       require 'config_builder/model/provisioner/puppet_server'


### PR DESCRIPTION
We needed the file provisioner to copy files from host to vms but noticed it wasn't included as part of the provisioner model.