### PR TITLE
Support for type arg in synced_folder parameter.

### DIFF
--- a/lib/config_builder/model/synced_folder.rb
+++ b/lib/config_builder/model/synced_folder.rb
@@ -24,6 +24,10 @@ class ConfigBuilder::Model::SyncedFolder < ConfigBuilder::Model::Base
   #   @return [Boolean] If the mount point should use NFS
   def_model_attribute :nfs
 
+  # @!attribute [rw] type
+  #   @return [String] The method for syncing folder to guest.
+  def_model_attribute :type
+
   def to_proc
     Proc.new do |vm_config|
       vm_config.synced_folder(attr(:host_path), attr(:guest_path), folder_opts)
@@ -37,6 +41,7 @@ class ConfigBuilder::Model::SyncedFolder < ConfigBuilder::Model::Base
     with_attr(:extra)   { |val| h[:extra]    = val }
     with_attr(:disabled) { |val| h[:disabled] = val }
     with_attr(:nfs)     { |val| h[:nfs]      = val }
+    with_attr(:type)    { |val| h[:type]     = val }
 
     h
   end


### PR DESCRIPTION
When using config_builder, I'm unable to choose between different types of how folders will be synced to guest.
For example I needed to use rsync instead of NFS, but nfs settings to false didn't work. And what if I want some other method? Don't know if this code change is the "clean way" how to solve this problem, but it works for me.

Thanks
Lukas