### PR TITLE
Run options

### DIFF
--- a/lib/config_builder/model/provisioner/file.rb
+++ b/lib/config_builder/model/provisioner/file.rb
@@ -11,11 +11,16 @@ class ConfigBuilder::Model::Provisioner::File < ConfigBuilder::Model::Base
   #     determined by running vagrant ssh-config, and defaults to "vagrant".
   def_model_attribute :destination
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  def_model_attribute :run
+
   def to_proc
     Proc.new do |vm_config|
       vm_config.provision :file do |file_config|
-        with_attr(:source)        { |val| file_config.source = val }
+        with_attr(:source)        { |val| file_config.source      = val }
         with_attr(:destination)   { |val| file_config.destination = val }
+        with_attr(:run)           { |val| file_config.run         = val }
       end
     end
   end

--- a/lib/config_builder/model/provisioner/puppet.rb
+++ b/lib/config_builder/model/provisioner/puppet.rb
@@ -21,6 +21,10 @@ class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
   #   @return [String] An arbitrary set of arguments for the `puppet` command
   attr_accessor :options
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  def_model_attribute :run
+
   def to_proc
     Proc.new do |vm_config|
       vm_config.provision :puppet do |puppet_config|
@@ -29,6 +33,7 @@ class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
         with_attr(:module_path)    { |val| puppet_config.module_path    = val }
         with_attr(:facter)         { |val| puppet_config.facter         = val }
         with_attr(:options)        { |val| puppet_config.options        = val }
+        with_attr(:run)            { |val| puppet_config.run            = val }
       end
     end
   end

--- a/lib/config_builder/model/provisioner/puppet_server.rb
+++ b/lib/config_builder/model/provisioner/puppet_server.rb
@@ -13,6 +13,10 @@ class ConfigBuilder::Model::Provisioner::PuppetServer < ConfigBuilder::Model::Ba
   #   @return [String]
   attr_accessor :options
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  attr_accessor :run
+
   def to_proc
     Proc.new do |vm_config|
       vm_config.provision :puppet_server do |puppet_config|

--- a/lib/config_builder/model/provisioner/shell.rb
+++ b/lib/config_builder/model/provisioner/shell.rb
@@ -17,13 +17,19 @@ class ConfigBuilder::Model::Provisioner::Shell < ConfigBuilder::Model::Base
   #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
   def_model_attribute :run
 
+  def initialize
+    @defauts = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :shell do |shell_config|
+      vm_config.provision :shell, run: attr(:run) do |shell_config|
         with_attr(:inline) { |val| shell_config.inline = val }
         with_attr(:path)   { |val| shell_config.path   = val }
         with_attr(:args)   { |val| shell_config.args   = val }
-        with_attr(:run)    { |val| shell_config.run    = val )
+#        with_attr(:run)    { |val| shell_config.run    = val }
       end
     end
   end

--- a/lib/config_builder/model/provisioner/shell.rb
+++ b/lib/config_builder/model/provisioner/shell.rb
@@ -13,12 +13,17 @@ class ConfigBuilder::Model::Provisioner::Shell < ConfigBuilder::Model::Base
   #   @return [String] A string acting as an argument vector to the command.
   def_model_attribute :args
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  def_model_attribute :run
+
   def to_proc
     Proc.new do |vm_config|
       vm_config.provision :shell do |shell_config|
         with_attr(:inline) { |val| shell_config.inline = val }
         with_attr(:path)   { |val| shell_config.path   = val }
         with_attr(:args)   { |val| shell_config.args   = val }
+        with_attr(:run)    { |val| shell_config.run    = val )
       end
     end
   end

--- a/lib/config_builder/model/provisioner/shell.rb
+++ b/lib/config_builder/model/provisioner/shell.rb
@@ -18,7 +18,7 @@ class ConfigBuilder::Model::Provisioner::Shell < ConfigBuilder::Model::Base
   def_model_attribute :run
 
   def initialize
-    @defauts = {
+    @defaults = {
      :run => 'once',
     }
   end

--- a/lib/config_builder/version.rb
+++ b/lib/config_builder/version.rb
@@ -1,3 +1,3 @@
 module ConfigBuilder
-  VERSION = '0.14.1'
+  VERSION = '0.14.0'
 end

--- a/lib/config_builder/version.rb
+++ b/lib/config_builder/version.rb
@@ -1,3 +1,3 @@
 module ConfigBuilder
-  VERSION = '0.14.0'
+  VERSION = '0.14.1'
 end


### PR DESCRIPTION
This PR adds the ability to specify that a provisioner use the "run: always" option described at https://docs.vagrantup.com/v2/provisioning/basic_usage.html